### PR TITLE
Bugfix: Projects could not be deleted on file server

### DIFF
--- a/sophomorix-samba/modules/SophomorixSambaAD.pm
+++ b/sophomorix-samba/modules/SophomorixSambaAD.pm
@@ -1558,17 +1558,14 @@ sub AD_group_kill {
 	} elsif ($type eq "project"){
             # delete the share, when succesful the group
             if ($smb_share ne  "unknown"){
+                my $smbclient_command_rmdir = $ref_sophomorix_config->{'INI'}{'EXECUTABLES'}{'SMBCLIENT'}.
+                    " --debuglevel=0 -U ".$DevelConf::sophomorix_file_admin."%'******' ".
+                    $unc." -c 'deltree \"$smb_rel_path_share\";'";
 
-                # rewrite smb_dir with msdfs root
-                $smb_share=&Sophomorix::SophomorixBase::rewrite_smb_path($smb_share,$ref_sophomorix_config);
+                my $return1=&Sophomorix::SophomorixBase::smb_command($smbclient_command_rmdir,$smb_admin_pass);
 
-                my $smb = new Filesys::SmbClient(username  => $DevelConf::sophomorix_file_admin,
-                                                 password  => $smb_admin_pass,
-                                                 debug     => 0);
-
-                my $return1=$smb->rmdir_recurse($smb_share);
-                if($return1==1){
-                    print "OK: Deleted with succes $smb_share\n"; # smb://linuxmuster.local/<school>/subdir1/subdir2
+                if($return1==0){
+                    print "OK: Deleted with success $smb_share\n"; # smb://linuxmuster.local/<school>/subdir1/subdir2
                     # deleting the AD account
                     my $command=$ref_sophomorix_config->{'INI'}{'EXECUTABLES'}{'SAMBA_TOOL'}.
                         " group delete ". $group;


### PR DESCRIPTION
If you use an extra file server in Linuxmuster, the project folders cannot be deleted:

```
#### /usr/sbin/sophomorix-project started ...                                 ####                                    
#### Killing group p_aabk-musik-ag (project, aabk) (start):                   ####                                    
#### Removing object p_aabk-musik-ag from sophomorix attributes               ####                                    
you don't have a /tmp/.smb/smb.conf, I will create it (empty file)                                                    
Use of uninitialized value $return1 in numeric eq (==) at /usr/share/perl5/Sophomorix/SophomorixSambaAD.pm line 1563. 
ERROR: rmdir_recurse smb://###SERVERNAME###/aabk//share/projects/p_aabk-musik-ag Permission denied                
#### Killing group p_aabk-musik-ag (project, aabk) (end)                      ####                                    
#### /usr/sbin/sophomorix-project terminated regularly                        ####  
``` 

The change uses the SMB "deltree" to delete the folder. This works on the local server as well as on a file server.