### PR TITLE
Allow username to start with an alpha-numeric character

### DIFF
--- a/sophomorix-samba/modules/SophomorixBase.pm
+++ b/sophomorix-samba/modules/SophomorixBase.pm
@@ -5717,10 +5717,10 @@ sub create_test_login {
 	    my $error_message="'".$login_wish."' is to short for a login name! (Minimum number of characters for a login name is 2) ".
                               "| $file LINE $line_num: $ref_users_file->{$school}{'identifier_ascii'}{$identifier_ascii}{LINE_OLD}";
             return ("---",$error_message);
-        } elsif (not $login_wish=~m/^[a-z]+/){
-#	    my $error_message="'".$login_wish."' does not begin with a-z ".
+        } elsif (not $login_wish=~m/^[[:alnum:]]+/){
+#	    my $error_message="'".$login_wish."' does not begin with an alpha-numeric character ".
 #                              "| $file LINE $line_num: $ref_users_file->{$file}{'identifier_ascii'}{$identifier_ascii}{LINE_OLD}";
-	    my $error_message="'".$login_wish."' does not begin with a-z ".
+	    my $error_message="'".$login_wish."' does not begin with an alpha-numeric character ".
                               "| $file LINE $line_num: $ref_users_file->{$school}{'identifier_ascii'}{$identifier_ascii}{LINE_OLD}";
              return ("---",$error_message);
         } elsif (exists $ref_forbidden_logins->{'FORBIDDEN'}{$login_wish}){


### PR DESCRIPTION
There's no clue for the oldest and most restrictive username style (sAMAccountName) to not start with a upper-/lowercase or number character, so it should be used the alpha-numeric regex here.

Disallowed characters are: `" / \ [ ] : ; | = , + * ? < >` and shouldn't be longer than 20 chars.
Source: https://learn.microsoft.com/en-us/windows/win32/adschema/a-samaccountname